### PR TITLE
Support for object rest spread in tests {...obj}

### DIFF
--- a/src/parser/codeParser.ts
+++ b/src/parser/codeParser.ts
@@ -6,7 +6,8 @@ function codeParser(sourceCode) {
   const parserOptions = {
     plugins: [
       "jsx",
-      "typescript"
+      "typescript",
+      "objectRestSpread"
     ],
     sourceType: "module",
     tokens: true,


### PR DESCRIPTION
Following test-case is not correctly parsed in current version. By modifying babel/parser options following test-case is considered as valid.

```javascript
it('checks additional properties', () => {
      const request = {
        ...requestDefinition,
        body: {id: '1234', limit: 1},
      }

```